### PR TITLE
Padding Layer

### DIFF
--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
@@ -426,8 +426,8 @@ public:
 
    /** Perform the complete backward propagation step in a Zero Padding Layer. The gradients
     *  at the padded positions get discarded. */
-   static void ZeroPad2DBackward(std::vector<TMatrixT<AReal>> &activationGradientsBackward,
-                                 const std::vector<TMatrixT<AReal>> &activationGradients,
+   static void ZeroPad2DBackward(std::vector<TCpuMatrix<AReal>> &activationGradientsBackward,
+                                 const std::vector<TCpuMatrix<AReal>> &activationGradients,
                                  size_t topPad, size_t bottomPad, size_t leftPad,
                                  size_t rightPad, size_t outputHeight, size_t outputWidth,
                                  size_t batchSize, size_t depth);

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
@@ -415,8 +415,8 @@ public:
     *  padding dimensions specified.
     *   */
    static void ZeroPad2DForward(TCpuMatrix<AReal> &A, const TCpuMatrix<AReal> &B, 
-                                                   size_t topPad, size_t bottomPad, size_t leftPad,
-                                                   size_t rightPad);
+                                size_t topPad, size_t bottomPad, size_t leftPad,
+                                size_t rightPad, size_t outputHeight, size_t outputWidth);
 
    ///@}
 
@@ -427,9 +427,10 @@ public:
    /** Perform the complete backward propagation step in a Zero Padding Layer. The gradients
     *  at the padded positions get discarded. */
    static void ZeroPad2DBackward(std::vector<TMatrixT<AReal>> &activationGradientsBackward,
-                                    const std::vector<TMatrixT<AReal>> &activationGradients,
-                                    const std::vector<TMatrixT<AReal>> &indexMatrix, size_t batchSize, size_t depth,
-                                    size_t nLocalViews);
+                                 const std::vector<TMatrixT<AReal>> &activationGradients,
+                                 size_t topPad, size_t bottomPad, size_t leftPad,
+                                 size_t rightPad, size_t outputHeight, size_t outputWidth,
+                                 size_t batchSize, size_t depth);
    ///@}
 
    //____________________________________________________________________________

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cpu.h
@@ -405,6 +405,35 @@ public:
 
    //____________________________________________________________________________
    //
+   //  Zero Padding Layer Propagation
+   //____________________________________________________________________________
+   /** @name Forward Propagation in Zero Padding Layer
+    */
+   ///@{
+
+  /** Zero Pad the matrix \p B to the matrix \p A, using the
+    *  padding dimensions specified.
+    *   */
+   static void ZeroPad2DForward(TCpuMatrix<AReal> &A, const TCpuMatrix<AReal> &B, 
+                                                   size_t topPad, size_t bottomPad, size_t leftPad,
+                                                   size_t rightPad);
+
+   ///@}
+
+   /** @name Backward Propagation in Zero Padding Layer
+    */
+   ///@{
+
+   /** Perform the complete backward propagation step in a Zero Padding Layer. The gradients
+    *  at the padded positions get discarded. */
+   static void ZeroPad2DBackward(std::vector<TMatrixT<AReal>> &activationGradientsBackward,
+                                    const std::vector<TMatrixT<AReal>> &activationGradients,
+                                    const std::vector<TMatrixT<AReal>> &indexMatrix, size_t batchSize, size_t depth,
+                                    size_t nLocalViews);
+   ///@}
+
+   //____________________________________________________________________________
+   //
    //  Reshape Layer Propagation
    //____________________________________________________________________________
    /** @name Forward and Backward Propagation in Reshape Layer

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
@@ -424,8 +424,8 @@ public:
     *  padding dimensions specified.
     *   */
    static void ZeroPad2DForward(TCudaMatrix<AFloat> &A, const TCudaMatrix<AFloat> &B, 
-                                                   size_t topPad, size_t bottomPad, size_t leftPad,
-                                                   size_t rightPad);
+                                size_t topPad, size_t bottomPad, size_t leftPad,
+                                size_t rightPad, size_t outputHeight, size_t outputWidth);
 
    ///@}
 
@@ -435,10 +435,11 @@ public:
 
    /** Perform the complete backward propagation step in a Zero Padding Layer. The gradients
     *  at the padded positions get discarded. */
-   static void ZeroPad2DBackward(std::vector<TMatrixT<AReal>> &activationGradientsBackward,
-                                    const std::vector<TMatrixT<AReal>> &activationGradients,
-                                    const std::vector<TMatrixT<AReal>> &indexMatrix, size_t batchSize, size_t depth,
-                                    size_t nLocalViews);
+   static void ZeroPad2DBackward(std::vector<TCudaMatrix<AFloat>> &activationGradientsBackward,
+                                 const std::vector<TCudaMatrix<AFloat>> &activationGradients,
+                                 size_t topPad, size_t bottomPad, size_t leftPad,
+                                 size_t rightPad, size_t outputHeight, size_t outputWidth,
+                                 size_t batchSize, size_t depth);
    ///@}
 
    //____________________________________________________________________________

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Cuda.h
@@ -414,6 +414,35 @@ public:
 
    //____________________________________________________________________________
    //
+   //  Zero Padding Layer Propagation
+   //____________________________________________________________________________
+   /** @name Forward Propagation in Zero Padding Layer
+    */
+   ///@{
+
+  /** Zero Pad the matrix \p B to the matrix \p A, using the
+    *  padding dimensions specified.
+    *   */
+   static void ZeroPad2DForward(TCudaMatrix<AFloat> &A, const TCudaMatrix<AFloat> &B, 
+                                                   size_t topPad, size_t bottomPad, size_t leftPad,
+                                                   size_t rightPad);
+
+   ///@}
+
+   /** @name Backward Propagation in Zero Padding Layer
+    */
+   ///@{
+
+   /** Perform the complete backward propagation step in a Zero Padding Layer. The gradients
+    *  at the padded positions get discarded. */
+   static void ZeroPad2DBackward(std::vector<TMatrixT<AReal>> &activationGradientsBackward,
+                                    const std::vector<TMatrixT<AReal>> &activationGradients,
+                                    const std::vector<TMatrixT<AReal>> &indexMatrix, size_t batchSize, size_t depth,
+                                    size_t nLocalViews);
+   ///@}
+
+   //____________________________________________________________________________
+   //
    //  Reshape Layer Propagation
    //____________________________________________________________________________
    /** @name Forward and Backward Propagation in Reshape Layer

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h
@@ -432,6 +432,37 @@ public:
                                     const std::vector<TMatrixT<AReal>> &indexMatrix, size_t batchSize, size_t depth,
                                     size_t nLocalViews);
    ///@}
+
+
+   //____________________________________________________________________________
+   //
+   //  Zero Padding Layer Propagation
+   //____________________________________________________________________________
+   /** @name Forward Propagation in Zero Padding Layer
+    */
+   ///@{
+
+  /** Zero Pad the matrix \p B to the matrix \p A, using the
+    *  padding dimensions specified.
+    *   */
+   static void ZeroPad2DForward(TMatrixT<AReal> &A, const TMatrixT<AReal> &B, 
+                                                   size_t topPad, size_t bottomPad, size_t leftPad,
+                                                   size_t rightPad);
+
+   ///@}
+
+   /** @name Backward Propagation in Zero Padding Layer
+    */
+   ///@{
+
+   /** Perform the complete backward propagation step in a Zero Padding Layer. The gradients
+    *  at the padded positions get discarded. */
+   static void ZeroPad2DBackward(std::vector<TMatrixT<AReal>> &activationGradientsBackward,
+                                    const std::vector<TMatrixT<AReal>> &activationGradients,
+                                    const std::vector<TMatrixT<AReal>> &indexMatrix, size_t batchSize, size_t depth,
+                                    size_t nLocalViews);
+   ///@}
+
    //____________________________________________________________________________
    //
    //  Reshape Layer Propagation

--- a/tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h
+++ b/tmva/tmva/inc/TMVA/DNN/Architectures/Reference.h
@@ -446,8 +446,8 @@ public:
     *  padding dimensions specified.
     *   */
    static void ZeroPad2DForward(TMatrixT<AReal> &A, const TMatrixT<AReal> &B, 
-                                                   size_t topPad, size_t bottomPad, size_t leftPad,
-                                                   size_t rightPad);
+                                size_t topPad, size_t bottomPad, size_t leftPad,
+                                size_t rightPad, size_t outputHeight, size_t outputWidth);
 
    ///@}
 
@@ -458,11 +458,12 @@ public:
    /** Perform the complete backward propagation step in a Zero Padding Layer. The gradients
     *  at the padded positions get discarded. */
    static void ZeroPad2DBackward(std::vector<TMatrixT<AReal>> &activationGradientsBackward,
-                                    const std::vector<TMatrixT<AReal>> &activationGradients,
-                                    const std::vector<TMatrixT<AReal>> &indexMatrix, size_t batchSize, size_t depth,
-                                    size_t nLocalViews);
+                                 const std::vector<TMatrixT<AReal>> &activationGradients,
+                                 size_t topPad, size_t bottomPad, size_t leftPad,
+                                 size_t rightPad, size_t outputHeight, size_t outputWidth,
+                                 size_t batchSize, size_t depth);
    ///@}
-
+   
    //____________________________________________________________________________
    //
    //  Reshape Layer Propagation

--- a/tmva/tmva/inc/TMVA/DNN/CNN/PaddingLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/PaddingLayer.h
@@ -59,7 +59,7 @@ private:
 
 public:
 	/*! Constructor. */
-	TPaddingLayer(size_t BatchSize, size_t inputDepth, size_t inputHeight, size_t inputWidth, size_t TopPad, size_t BottomPad, size_t LeftPad, size_t RightPad);
+	TPaddingLayer(size_t BatchSize, size_t inputDepth, size_t inputHeight, size_t inputWidth, size_t depth, size_t height, size_t width, size_t TopPad, size_t BottomPad, size_t LeftPad, size_t RightPad);
 
 	/*! Copy the conv layer provided as a pointer */
 	TPaddingLayer(TPaddingLayer<Architecture_t> *layer);
@@ -108,8 +108,9 @@ public:
 
 template <typename Architecture_t>
 TPaddingLayer<Architecture_t>::TPaddingLayer(size_t batchSize, size_t inputDepth, size_t inputHeight, size_t inputWidth,
+                                             size_t depth, size_t height, size_t width,
                                              size_t topPad, size_t bottomPad, size_t leftPad, size_t rightPad)
-   : VGeneralLayer<Architecture_t>(batchSize, inputDepth, inputHeight, inputWidth, 0, 0, 0, 0, 0, 0, 0, 0,
+   : VGeneralLayer<Architecture_t>(batchSize, inputDepth, inputHeight, inputWidth, depth, height, width, 0, 0, 0, 0, 0,
                                    0, batchSize, inputDepth, calculateDimension(inputHeight, inputWidth, leftPad, rightPad, topPad, bottomPad), EInitialization::kZero),
      fTopPad(topPad), fBottomPad(bottomPad), fLeftPad(leftPad), fRightPad(rightPad)
 {
@@ -173,7 +174,7 @@ auto TPaddingLayer<Architecture_t>::Print() const -> void
    std::cout << " PADDING Layer \t ";
    std::cout << "Input = ( " << this->GetInputDepth() << " , " <<  this->GetInputHeight() << " , " << this->GetInputWidth() << " ) ";
    if (this->GetOutput().size() > 0) {
-      std::cout << "\tOutput = ( " << this->GetOutput().size() << " , " << this->GetOutputHeight() << " , " << this->GetOutputWidth() << " ) ";
+      std::cout << "\tOutput = ( " << this->GetOutput().size() << " , " << this->GetOutput()[0].GetNrows() << " , " << this->GetOutput()[0].GetNcols() << " ) ";
    }
    std::cout << std::endl;
 }
@@ -184,10 +185,10 @@ auto TPaddingLayer<Architecture_t>::AddWeightsXMLTo(void *parent) -> void
    auto layerxml = gTools().xmlengine().NewChild(parent, 0, "PaddingLayer");
 
    // write info for padding layer
-   gTools().xmlengine().NewAttr(layerxml, 0, "Left Pad", gTools().StringFromInt(this->GetLeftPadding()));
-   gTools().xmlengine().NewAttr(layerxml, 0, "Right Pad", gTools().StringFromInt(this->GetRightPadding()));
-   gTools().xmlengine().NewAttr(layerxml, 0, "Top Pad", gTools().StringFromInt(this->GetTopPadding()));
-   gTools().xmlengine().NewAttr(layerxml, 0, "Bottom Pad", gTools().StringFromInt(this->GetBottomPadding()));
+   gTools().xmlengine().NewAttr(layerxml, 0, "LeftPad", gTools().StringFromInt(this->GetLeftPadding()));
+   gTools().xmlengine().NewAttr(layerxml, 0, "RightPad", gTools().StringFromInt(this->GetRightPadding()));
+   gTools().xmlengine().NewAttr(layerxml, 0, "TopPad", gTools().StringFromInt(this->GetTopPadding()));
+   gTools().xmlengine().NewAttr(layerxml, 0, "BottomPad", gTools().StringFromInt(this->GetBottomPadding()));
 
 
 }

--- a/tmva/tmva/inc/TMVA/DNN/CNN/PaddingLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/PaddingLayer.h
@@ -82,20 +82,26 @@ public:
 	                                             std::vector<Matrix_t> & /*inp1*/, std::vector<Matrix_t> &
 	                                             /*inp2*/);
 
-   	/*! Prints the info about the layer. */
-   	void Print() const;		
+  /*! Writes the information and the weights about the layer in an XML node. */
+  virtual void AddWeightsXMLTo(void *parent);
 
-   	size_t GetTopPadding() const {return fTopPad;}
+  /*! Read the information and the weights about the layer from XML node. */
+  virtual void ReadWeightsFromXML(void *parent);
 
-   	size_t GetBottomPadding() const {return fBottomPad;}
+  /*! Prints the info about the layer. */
+  void Print() const;		
 
-   	size_t GetLeftPadding() const {return fLeftPad;}
+  size_t GetTopPadding() const {return fTopPad;}
 
-   	size_t GetRightPadding() const {return fRightPad;}
+  size_t GetBottomPadding() const {return fBottomPad;}
 
-   	size_t GetOutputHeight() const {return outputHeight;}
+  size_t GetLeftPadding() const {return fLeftPad;}
 
-   	size_t GetOutputWidth() const {return outputWidth;}
+  size_t GetRightPadding() const {return fRightPad;}
+
+  size_t GetOutputHeight() const {return outputHeight;}
+
+  size_t GetOutputWidth() const {return outputWidth;}
 
 
 };
@@ -115,7 +121,7 @@ TPaddingLayer<Architecture_t>::TPaddingLayer(size_t batchSize, size_t inputDepth
 
 //_________________________________________________________________________________________________
 template <typename Architecture_t>
-TPaddingLayer<Architecture_t>::TPaddingLayer(TPadding<Architecture_t> *layer)
+TPaddingLayer<Architecture_t>::TPaddingLayer(TPaddingLayer<Architecture_t> *layer)
    : VGeneralLayer<Architecture_t>(layer), fTopPad(layer->GetTopPadding()), fBottomPad(layer->GetBottomPadding()),
    	fLeftPad(layer->GetLeftPadding()), fRightPad(layer->GetRightPadding())
 {
@@ -157,7 +163,7 @@ auto TPaddingLayer<Architecture_t>::Backward(std::vector<Matrix_t> &gradients_ba
 {
 	Architecture_t::ZeroPad2DBackward(gradients_backward, this->GetActivationGradients(), fTopPad, fBottomPad, fLeftPad,
 									  fRightPad, this->GetOutputHeight(), this->GetOutputWidth(), this->GetBatchSize(),
-									  this->GetDepth())
+									  this->GetDepth());
 }
 
 //_________________________________________________________________________________________________
@@ -206,3 +212,5 @@ size_t TPaddingLayer<Architecture_t>::calculateDimension(size_t imgHeight, size_
 
 } // namespace DNN
 } // namespace TMVA
+
+#endif

--- a/tmva/tmva/inc/TMVA/DNN/CNN/PaddingLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/PaddingLayer.h
@@ -1,0 +1,217 @@
+// @(#)root/tmva/tmva/dnn:$Id$
+// Author: Siddhartha Rao Kamalakara
+
+/**********************************************************************************
+ * Project: TMVA - a Root-integrated toolkit for multivariate data analysis       *
+ * Package: TMVA                                                                  *
+ * Class  : TConvLayer                                                            *
+ * Web    : http://tmva.sourceforge.net                                           *
+ *                                                                                *
+ * Description:                                                                   *
+ *      Convolutional Deep Neural Network Layer                                   *
+ *                                                                                *
+ * Authors (alphabetical):                                                        *
+ *      Siddhartha Rao Kamalakara        <srk97c@gmail.com>  - CERN, Switzerland  *
+ *                                                                                *
+ * Copyright (c) 2005-2015:                                                       *
+ *      CERN, Switzerland                                                         *
+ *      U. of Victoria, Canada                                                    *
+ *      MPI-K Heidelberg, Germany                                                 *
+ *      U. of Bonn, Germany                                                       *
+ *                                                                                *
+ * Redistribution and use in source and binary forms, with or without             *
+ * modification, are permitted according to the terms listed in LICENSE           *
+ * (http://tmva.sourceforge.net/LICENSE)                                          *
+ **********************************************************************************/
+
+#ifndef TMVA_CNN_CONVLAYER
+#define TMVA_CNN_CONVLAYER
+
+#include "TMatrix.h"
+
+#include "TMVA/DNN/GeneralLayer.h"
+#include "TMVA/DNN/Functions.h"
+
+#include <vector>
+#include <iostream>
+
+namespace TMVA {
+namespace DNN {
+namespace CNN {
+
+template <typename Architecture_t>
+class TPaddingLayer : public VGeneralLayer<Architecture_t>
+{
+
+public:
+   using Matrix_t = typename Architecture_t::Matrix_t;
+   using Scalar_t = typename Architecture_t::Scalar_t;
+
+private:
+	size_t fTopPad;
+	size_t fBottomPad;
+	size_t fLeftPad;
+	size_t fRightPad;
+	size_t outputWidth;
+	size_t outputHeight;
+
+	size_t calculateDimension(size_t imgHeight, size_t imgWidth, size_t pad_left, size_t pad_right, size_t pad_top, size_t pad_bottom);
+
+public:
+	/*! Constructor. */
+	TPaddingLayer(size_t BatchSize, size_t inputDepth, size_t inputHeight, size_t inputWidth, size_t TopPad, size_t BottomPad, size_t LeftPad, size_t RightPad);
+
+	/*! Copy the conv layer provided as a pointer */
+	TPaddingLayer(TPaddingLayer<Architecture_t> *layer);
+
+	/*! Copy constructor. */
+	TPaddingLayer(const TPaddingLayer &);
+
+	/*! Destructor. */
+	~TPaddingLayer();
+
+	/*! Pads the input array with the dimensions given by
+	 *  the user. Padding is done in two dimensions for each
+	 *  example in the batch */
+	void Forward(std::vector<Matrix_t> &input, bool applyDropout = false);
+
+	/*! Discards the gradients through the padded inputs
+	 *  since they are zero padded */
+	void Backward(std::vector<Matrix_t> &gradients_backward,
+	                                             const std::vector<Matrix_t> & /*activations_backward*/,
+	                                             std::vector<Matrix_t> & /*inp1*/, std::vector<Matrix_t> &
+	                                             /*inp2*/);
+
+   	/*! Prints the info about the layer. */
+   	void Print() const;		
+
+   	size_t GetTopPadding() const {return fTopPad;}
+
+   	size_t GetBottomPadding() const {return fBottomPad;}
+
+   	size_t GetLeftPadding() const {return fLeftPad;}
+
+   	size_t GetRightPadding() const {return fRightPad;}
+
+   	size_t GetOutputHeight() const {return outputHeight;}
+
+   	size_t GetOutputWidth() const {return outputWidth;}
+
+
+};
+
+template <typename Architecture_t>
+TPaddingLayer<Architecture_t>::TPaddingLayer(size_t batchSize, size_t inputDepth, size_t inputHeight, size_t inputWidth,
+                                             size_t topPad, size_t bottomPad, size_t leftPad, size_t rightPad)
+   : VGeneralLayer<Architecture_t>(batchSize, inputDepth, inputHeight, inputWidth, 0, 0, 0, 0, 0, 0, 0, 0,
+                                   0, batchSize, inputDepth, calculateDimension(inputHeight, inputWidth, leftPad, rightPad, topPad, bottomPad), EInitialization::kZero),
+     fTopPad(topPad), fBottomPad(bottomPad), fLeftPad(leftPad), fRightPad(rightPad)
+{
+
+	this->outputHeight = inputHeight + topPad + bottomPad;
+	this->outputWidth = inputWidth + leftPad + rightPad;	
+}
+
+
+//_________________________________________________________________________________________________
+template <typename Architecture_t>
+TPaddingLayer<Architecture_t>::TPaddingLayer(TPadding<Architecture_t> *layer)
+   : VGeneralLayer<Architecture_t>(layer), fTopPad(layer->GetTopPadding()), fBottomPad(layer->GetBottomPadding()),
+   	fLeftPad(layer->GetLeftPadding()), fRightPad(layer->GetRightPadding())
+{
+}
+
+//_________________________________________________________________________________________________
+template <typename Architecture_t>
+TPaddingLayer<Architecture_t>::TPaddingLayer(const TPaddingLayer &layer)
+   : VGeneralLayer<Architecture_t>(layer), fTopPad(layer.fTopPad), fBottomPad(layer.fBottomPad),
+   	fLeftPad(layer.fLeftPad), fRightPad(layer.fRightPad)
+{
+   // Nothing to do here.
+}
+
+//_________________________________________________________________________________________________
+template <typename Architecture_t>
+TPaddingLayer<Architecture_t>::~TPaddingLayer()
+{
+   // Nothing to do here.
+}
+
+//_________________________________________________________________________________________________
+template <typename Architecture_t>
+auto TReshapeLayer<Architecture_t>::Forward(std::vector<Matrix_t> &input, bool /*applyDropout*/) -> void
+{
+
+  for (size_t i = 0; i < this->GetBatchSize(); i++) {
+     Architecture_t::ZeroPad2DForward(this->GetOutputAt(i), input[i], fTopPad, fBottomPad, fRightPad, fLeftPad, this->GetOutputHeight(), this->GetOutputWidth());
+  }
+
+}
+
+//_________________________________________________________________________________________________
+template <typename Architecture_t>
+auto TPaddingLayer<Architecture_t>::Backward(std::vector<Matrix_t> &gradients_backward,
+                                             const std::vector<Matrix_t> & /*activations_backward*/,
+                                             std::vector<Matrix_t> & /*inp1*/, std::vector<Matrix_t> &
+                                             /*inp2*/) -> void
+{
+   // in case of first layer size is zero - do nothing
+   if (gradients_backward.size() == 0) return; 
+   if (fFlattening) {
+      size_t size = gradients_backward.size();
+      size_t nRows = gradients_backward[0].GetNrows();
+      size_t nCols = gradients_backward[0].GetNcols();
+      Architecture_t::Deflatten(gradients_backward, this->GetActivationGradientsAt(0), size, nRows, nCols);
+   } else {
+      for (size_t i = 0; i < this->GetBatchSize(); i++) {
+         Architecture_t::Reshape(gradients_backward[i], this->GetActivationGradientsAt(i));
+      }
+   }
+}
+
+//_________________________________________________________________________________________________
+template <typename Architecture_t>
+auto TReshapeLayer<Architecture_t>::Print() const -> void
+{
+   std::cout << " PADDING Layer \t ";
+   std::cout << "Input = ( " << this->GetInputDepth() << " , " <<  this->GetInputHeight() << " , " << this->GetInputWidth() << " ) ";
+   if (this->GetOutput().size() > 0) {
+      std::cout << "\tOutput = ( " << this->GetOutput().size() << " , " << this->GetOutput()[0].GetNrows() << " , " << this->GetOutput()[0].GetNcols() << " ) ";
+   }
+   std::cout << std::endl;
+}
+
+template <typename Architecture_t>
+auto TReshapeLayer<Architecture_t>::AddWeightsXMLTo(void *parent) -> void
+{
+   auto layerxml = gTools().xmlengine().NewChild(parent, 0, "PaddingLayer");
+
+   // write info for reshapelayer
+   gTools().xmlengine().NewAttr(layerxml, 0, "Depth", gTools().StringFromInt(this->GetDepth()));
+   gTools().xmlengine().NewAttr(layerxml, 0, "Height", gTools().StringFromInt(this->GetHeight()));
+   gTools().xmlengine().NewAttr(layerxml, 0, "Width", gTools().StringFromInt(this->GetWidth()));
+   gTools().xmlengine().NewAttr(layerxml, 0, "Flattening", gTools().StringFromInt(this->isFlattening()));
+
+
+}
+
+//______________________________________________________________________________
+template <typename Architecture_t>
+void TPaddingLayer<Architecture_t>::ReadWeightsFromXML(void * /*parent*/)
+{
+   // no info to read
+}
+
+
+template <typename Architecture_t>
+size_t TPaddingLayer<Architecture_t>::calculateDimension(size_t imgHeight, size_t imgWidth, size_t pad_left, size_t pad_right, size_t pad_top, size_t pad_bottom){
+
+	size_t height = imgHeight + pad_top + pad_bottom;
+	size_t width  = imgWidth + pad_left + pad_right;
+
+	return height*width;
+}
+
+
+} // namespace DNN
+} // namespace TMVA

--- a/tmva/tmva/inc/TMVA/DNN/CNN/PaddingLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/PaddingLayer.h
@@ -212,5 +212,6 @@ size_t TPaddingLayer<Architecture_t>::calculateDimension(size_t imgHeight, size_
 
 } // namespace DNN
 } // namespace TMVA
+}
 
 #endif

--- a/tmva/tmva/inc/TMVA/DNN/CNN/PaddingLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/PaddingLayer.h
@@ -24,8 +24,8 @@
  * (http://tmva.sourceforge.net/LICENSE)                                          *
  **********************************************************************************/
 
-#ifndef TMVA_CNN_PADDINGLAYER
-#define TMVA_CNN_PADDINGLAYER
+#ifndef TMVA_CNN_PADDINGLAYER2D
+#define TMVA_CNN_PADDINGLAYER2D
 
 #include "TMatrix.h"
 
@@ -40,7 +40,7 @@ namespace DNN {
 namespace CNN {
 
 template <typename Architecture_t>
-class TPaddingLayer : public VGeneralLayer<Architecture_t>
+class TPaddingLayer2D : public VGeneralLayer<Architecture_t>
 {
 
 public:
@@ -59,16 +59,16 @@ private:
 
 public:
 	/*! Constructor. */
-	TPaddingLayer(size_t BatchSize, size_t inputDepth, size_t inputHeight, size_t inputWidth, size_t depth, size_t height, size_t width, size_t TopPad, size_t BottomPad, size_t LeftPad, size_t RightPad);
+	TPaddingLayer2D(size_t BatchSize, size_t inputDepth, size_t inputHeight, size_t inputWidth, size_t depth, size_t height, size_t width, size_t TopPad, size_t BottomPad, size_t LeftPad, size_t RightPad);
 
 	/*! Copy the conv layer provided as a pointer */
-	TPaddingLayer(TPaddingLayer<Architecture_t> *layer);
+	TPaddingLayer2D(TPaddingLayer2D<Architecture_t> *layer);
 
 	/*! Copy constructor. */
-	TPaddingLayer(const TPaddingLayer &);
+	TPaddingLayer2D(const TPaddingLayer2D &);
 
 	/*! Destructor. */
-	~TPaddingLayer();
+	~TPaddingLayer2D();
 
 	/*! Pads the input array with the dimensions given by
 	 *  the user. Padding is done in two dimensions for each
@@ -107,7 +107,7 @@ public:
 };
 
 template <typename Architecture_t>
-TPaddingLayer<Architecture_t>::TPaddingLayer(size_t batchSize, size_t inputDepth, size_t inputHeight, size_t inputWidth,
+TPaddingLayer2D<Architecture_t>::TPaddingLayer2D(size_t batchSize, size_t inputDepth, size_t inputHeight, size_t inputWidth,
                                              size_t depth, size_t height, size_t width,
                                              size_t topPad, size_t bottomPad, size_t leftPad, size_t rightPad)
    : VGeneralLayer<Architecture_t>(batchSize, inputDepth, inputHeight, inputWidth, depth, height, width, 0, 0, 0, 0, 0,
@@ -116,13 +116,13 @@ TPaddingLayer<Architecture_t>::TPaddingLayer(size_t batchSize, size_t inputDepth
 {
 
 	this->outputHeight = inputHeight + topPad + bottomPad;
-	this->outputWidth = inputWidth + leftPad + rightPad;	
+	this->outputWidth = inputWidth + leftPad + rightPad;
 }
 
 
 //_________________________________________________________________________________________________
 template <typename Architecture_t>
-TPaddingLayer<Architecture_t>::TPaddingLayer(TPaddingLayer<Architecture_t> *layer)
+TPaddingLayer2D<Architecture_t>::TPaddingLayer2D(TPaddingLayer2D<Architecture_t> *layer)
    : VGeneralLayer<Architecture_t>(layer), fTopPad(layer->GetTopPadding()), fBottomPad(layer->GetBottomPadding()),
    	fLeftPad(layer->GetLeftPadding()), fRightPad(layer->GetRightPadding())
 {
@@ -130,7 +130,7 @@ TPaddingLayer<Architecture_t>::TPaddingLayer(TPaddingLayer<Architecture_t> *laye
 
 //_________________________________________________________________________________________________
 template <typename Architecture_t>
-TPaddingLayer<Architecture_t>::TPaddingLayer(const TPaddingLayer &layer)
+TPaddingLayer2D<Architecture_t>::TPaddingLayer2D(const TPaddingLayer2D &layer)
    : VGeneralLayer<Architecture_t>(layer), fTopPad(layer.fTopPad), fBottomPad(layer.fBottomPad),
    	fLeftPad(layer.fLeftPad), fRightPad(layer.fRightPad)
 {
@@ -139,14 +139,14 @@ TPaddingLayer<Architecture_t>::TPaddingLayer(const TPaddingLayer &layer)
 
 //_________________________________________________________________________________________________
 template <typename Architecture_t>
-TPaddingLayer<Architecture_t>::~TPaddingLayer()
+TPaddingLayer2D<Architecture_t>::~TPaddingLayer2D()
 {
    // Nothing to do here.
 }
 
 //_________________________________________________________________________________________________
 template <typename Architecture_t>
-auto TPaddingLayer<Architecture_t>::Forward(std::vector<Matrix_t> &input, bool /*applyDropout*/) -> void
+auto TPaddingLayer2D<Architecture_t>::Forward(std::vector<Matrix_t> &input, bool /*applyDropout*/) -> void
 {
 
   for (size_t i = 0; i < this->GetBatchSize(); i++) {
@@ -157,7 +157,7 @@ auto TPaddingLayer<Architecture_t>::Forward(std::vector<Matrix_t> &input, bool /
 
 //_________________________________________________________________________________________________
 template <typename Architecture_t>
-auto TPaddingLayer<Architecture_t>::Backward(std::vector<Matrix_t> &gradients_backward,
+auto TPaddingLayer2D<Architecture_t>::Backward(std::vector<Matrix_t> &gradients_backward,
                                              const std::vector<Matrix_t> & /*activations_backward*/,
                                              std::vector<Matrix_t> & /*inp1*/, std::vector<Matrix_t> &
                                              /*inp2*/) -> void
@@ -169,7 +169,7 @@ auto TPaddingLayer<Architecture_t>::Backward(std::vector<Matrix_t> &gradients_ba
 
 //_________________________________________________________________________________________________
 template <typename Architecture_t>
-auto TPaddingLayer<Architecture_t>::Print() const -> void
+auto TPaddingLayer2D<Architecture_t>::Print() const -> void
 {
    std::cout << " PADDING Layer \t ";
    std::cout << "Input = ( " << this->GetInputDepth() << " , " <<  this->GetInputHeight() << " , " << this->GetInputWidth() << " ) ";
@@ -180,9 +180,9 @@ auto TPaddingLayer<Architecture_t>::Print() const -> void
 }
 
 template <typename Architecture_t>
-auto TPaddingLayer<Architecture_t>::AddWeightsXMLTo(void *parent) -> void
+auto TPaddingLayer2D<Architecture_t>::AddWeightsXMLTo(void *parent) -> void
 {
-   auto layerxml = gTools().xmlengine().NewChild(parent, 0, "PaddingLayer");
+   auto layerxml = gTools().xmlengine().NewChild(parent, 0, "PaddingLayer2D");
 
    // write info for padding layer
    gTools().xmlengine().NewAttr(layerxml, 0, "LeftPad", gTools().StringFromInt(this->GetLeftPadding()));
@@ -195,14 +195,14 @@ auto TPaddingLayer<Architecture_t>::AddWeightsXMLTo(void *parent) -> void
 
 //______________________________________________________________________________
 template <typename Architecture_t>
-void TPaddingLayer<Architecture_t>::ReadWeightsFromXML(void * /*parent*/)
+void TPaddingLayer2D<Architecture_t>::ReadWeightsFromXML(void * /*parent*/)
 {
    // no info to read
 }
 
 
 template <typename Architecture_t>
-size_t TPaddingLayer<Architecture_t>::calculateDimension(size_t imgHeight, size_t imgWidth, size_t pad_left, size_t pad_right, size_t pad_top, size_t pad_bottom){
+size_t TPaddingLayer2D<Architecture_t>::calculateDimension(size_t imgHeight, size_t imgWidth, size_t pad_left, size_t pad_right, size_t pad_top, size_t pad_bottom){
 
 	size_t height = imgHeight + pad_top + pad_bottom;
 	size_t width  = imgWidth + pad_left + pad_right;

--- a/tmva/tmva/inc/TMVA/DNN/DeepNet.h
+++ b/tmva/tmva/inc/TMVA/DNN/DeepNet.h
@@ -172,7 +172,7 @@ public:
    /*! Function for adding Padding Layer in the Deep Neural Network, with a given
     *  top, bottom, left and right paddings. It will take every matrix from the 
     *  previous layer and pad it with zeros to a matrix with new dimensions. */
-   TPaddingLayer<Architecture_t> *AddPaddingLayer(size_t topPad, size_t bottomPad, size_t leftPad, bool rightPad);
+   TPaddingLayer<Architecture_t> *AddPaddingLayer(size_t topPad, size_t bottomPad, size_t leftPad, size_t rightPad);
 
    /*! Function for adding Padding Layer in the Deep Neural Network, when
     *  the layer is already created. */

--- a/tmva/tmva/inc/TMVA/DNN/DeepNet.h
+++ b/tmva/tmva/inc/TMVA/DNN/DeepNet.h
@@ -565,6 +565,7 @@ TPaddingLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddPaddingLaye
    size_t inputDepth;
    size_t inputHeight;
    size_t inputWidth;
+   size_t depth;
    size_t height;
    size_t width;
    size_t outputNSlices = this->GetBatchSize();
@@ -582,8 +583,12 @@ TPaddingLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddPaddingLaye
       inputWidth = lastLayer->GetWidth();
    }
 
+   depth = inputDepth;
+   height = inputHeight + topPad + bottomPad;
+   width = inputWidth + leftPad + rightPad;
+
    TPaddingLayer<Architecture_t> *paddingLayer = new TPaddingLayer<Architecture_t>(
-      batchSize, inputDepth, inputHeight, inputWidth, topPad, bottomPad, leftPad, rightPad);
+      batchSize, inputDepth, inputHeight, inputWidth, depth, height, width, topPad, bottomPad, leftPad, rightPad);
 
    // But this creates a copy or what?
    fLayers.push_back(paddingLayer);

--- a/tmva/tmva/inc/TMVA/DNN/DeepNet.h
+++ b/tmva/tmva/inc/TMVA/DNN/DeepNet.h
@@ -14,6 +14,7 @@
  *      Akshay Vashistha     <akshayvashistha1995@gmail.com> - CERN, Switzerland  *
  *      Vladimir Ilievski    <ilievski.vladimir@live.com>  - CERN, Switzerland    *
  *      Saurav Shekhar       <sauravshekhar01@gmail.com> - CERN, Switzerland      *
+ *      Siddhartha Rao Kamalakara     <srk97c@gmail.com> - CERN, Switzerland      *
  *                                                                                *
  * Copyright (c) 2005-2015:                                                       *
  *      CERN, Switzerland                                                         *
@@ -40,6 +41,7 @@
 
 #include "TMVA/DNN/CNN/ConvLayer.h"
 #include "TMVA/DNN/CNN/MaxPoolLayer.h"
+#include "TMVA/DNN/CNN/PaddingLayer.h"
 
 #include "TMVA/DNN/RNN/RNNLayer.h"
 
@@ -166,6 +168,15 @@ public:
    /*! Function for adding Reshape Layer in the Deep Neural Network, when
     *  the layer is already created. */
    void AddReshapeLayer(TReshapeLayer<Architecture_t> *reshapeLayer);
+
+   /*! Function for adding Padding Layer in the Deep Neural Network, with a given
+    *  top, bottom, left and right paddings. It will take every matrix from the 
+    *  previous layer and pad it with zeros to a matrix with new dimensions. */
+   TPaddingLayer<Architecture_t> *AddPaddingLayer(size_t topPad, size_t bottomPad, size_t leftPad, bool rightPad);
+
+   /*! Function for adding Padding Layer in the Deep Neural Network, when
+    *  the layer is already created. */
+   void AddPaddingLayer(TPaddingLayer<Architecture_t> *paddingLayer);
 
 #ifdef HAVE_DAE   /// DAE functions
    /*! Function for adding Corruption layer in the Deep Neural Network,
@@ -544,6 +555,49 @@ void TDeepNet<Architecture_t, Layer_t>::AddBasicRNNLayer(TBasicRNNLayer<Architec
 {
    fLayers.push_back(basicRNNLayer);
 }
+
+//______________________________________________________________________________
+template <typename Architecture_t, typename Layer_t>
+TPaddingLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddPaddingLayer(size_t topPad, size_t bottomPad,
+                                                                                  size_t leftPad, size_t rightPad)
+{
+   size_t batchSize = this->GetBatchSize();
+   size_t inputDepth;
+   size_t inputHeight;
+   size_t inputWidth;
+   size_t height;
+   size_t width;
+   size_t outputNSlices = this->GetBatchSize();
+   size_t outputNRows;
+   size_t outputNCols;
+
+   if (fLayers.size() == 0) {
+      inputDepth = this->GetInputDepth();
+      inputHeight = this->GetInputHeight();
+      inputWidth = this->GetInputWidth();
+   } else {
+      Layer_t *lastLayer = fLayers.back();
+      inputDepth = lastLayer->GetDepth();
+      inputHeight = lastLayer->GetHeight();
+      inputWidth = lastLayer->GetWidth();
+   }
+
+   TPaddingLayer<Architecture_t> *paddingLayer = new TPaddingLayer<Architecture_t>(
+      batchSize, inputDepth, inputHeight, inputWidth, topPad, bottomPad, leftPad, rightPad);
+
+   // But this creates a copy or what?
+   fLayers.push_back(paddingLayer);
+
+   return paddingLayer;
+}
+
+//______________________________________________________________________________
+template <typename Architecture_t, typename Layer_t>
+void TDeepNet<Architecture_t, Layer_t>::AddPaddingLayer(TPaddingLayer<Architecture_t> *paddingLayer)
+{
+   fLayers.push_back(paddingLayer);
+}
+
 
 //DAE
 #ifdef HAVE_DAE

--- a/tmva/tmva/inc/TMVA/DNN/DeepNet.h
+++ b/tmva/tmva/inc/TMVA/DNN/DeepNet.h
@@ -172,11 +172,11 @@ public:
    /*! Function for adding Padding Layer in the Deep Neural Network, with a given
     *  top, bottom, left and right paddings. It will take every matrix from the 
     *  previous layer and pad it with zeros to a matrix with new dimensions. */
-   TPaddingLayer<Architecture_t> *AddPaddingLayer(size_t topPad, size_t bottomPad, size_t leftPad, size_t rightPad);
+   TPaddingLayer2D<Architecture_t> *AddPaddingLayer2D(size_t topPad, size_t bottomPad, size_t leftPad, size_t rightPad);
 
    /*! Function for adding Padding Layer in the Deep Neural Network, when
     *  the layer is already created. */
-   void AddPaddingLayer(TPaddingLayer<Architecture_t> *paddingLayer);
+   void AddPaddingLayer2D(TPaddingLayer2D<Architecture_t> *paddingLayer);
 
 #ifdef HAVE_DAE   /// DAE functions
    /*! Function for adding Corruption layer in the Deep Neural Network,
@@ -558,7 +558,7 @@ void TDeepNet<Architecture_t, Layer_t>::AddBasicRNNLayer(TBasicRNNLayer<Architec
 
 //______________________________________________________________________________
 template <typename Architecture_t, typename Layer_t>
-TPaddingLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddPaddingLayer(size_t topPad, size_t bottomPad,
+TPaddingLayer2D<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddPaddingLayer2D(size_t topPad, size_t bottomPad,
                                                                                   size_t leftPad, size_t rightPad)
 {
    size_t batchSize = this->GetBatchSize();
@@ -587,7 +587,7 @@ TPaddingLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddPaddingLaye
    height = inputHeight + topPad + bottomPad;
    width = inputWidth + leftPad + rightPad;
 
-   TPaddingLayer<Architecture_t> *paddingLayer = new TPaddingLayer<Architecture_t>(
+   TPaddingLayer2D<Architecture_t> *paddingLayer = new TPaddingLayer2D<Architecture_t>(
       batchSize, inputDepth, inputHeight, inputWidth, depth, height, width, topPad, bottomPad, leftPad, rightPad);
 
    // But this creates a copy or what?
@@ -598,7 +598,7 @@ TPaddingLayer<Architecture_t> *TDeepNet<Architecture_t, Layer_t>::AddPaddingLaye
 
 //______________________________________________________________________________
 template <typename Architecture_t, typename Layer_t>
-void TDeepNet<Architecture_t, Layer_t>::AddPaddingLayer(TPaddingLayer<Architecture_t> *paddingLayer)
+void TDeepNet<Architecture_t, Layer_t>::AddPaddingLayer2D(TPaddingLayer2D<Architecture_t> *paddingLayer)
 {
    fLayers.push_back(paddingLayer);
 }

--- a/tmva/tmva/inc/TMVA/MethodDL.h
+++ b/tmva/tmva/inc/TMVA/MethodDL.h
@@ -127,7 +127,7 @@ private:
                           TString delim);
 
    template <typename Architecture_t, typename Layer_t>
-   void ParsePaddingLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
+   void ParsePaddingLayer2D(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
                           std::vector<DNN::TDeepNet<Architecture_t, Layer_t>> &nets, TString layerString,
                           TString delim);
 

--- a/tmva/tmva/inc/TMVA/MethodDL.h
+++ b/tmva/tmva/inc/TMVA/MethodDL.h
@@ -127,6 +127,11 @@ private:
                           TString delim);
 
    template <typename Architecture_t, typename Layer_t>
+   void ParsePaddingLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
+                          std::vector<DNN::TDeepNet<Architecture_t, Layer_t>> &nets, TString layerString,
+                          TString delim);
+
+   template <typename Architecture_t, typename Layer_t>
    void ParseRnnLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
                       std::vector<DNN::TDeepNet<Architecture_t, Layer_t>> &nets, TString layerString, TString delim);
 

--- a/tmva/tmva/src/DNN/Architectures/Cpu/Propagation.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/Propagation.cxx
@@ -579,6 +579,25 @@ void TCpu<AFloat>::MaxPoolLayerBackward(std::vector<TCpuMatrix<AFloat>> &activat
    }
 }
 
+//______________________________________________________________________________
+template <typename AFloat>
+void TCpu<AFloat>::ZeroPad2DForward(TCpuMatrix<AFloat> &A, const TCpuMatrix<AFloat> &B, size_t topPad, size_t bottomPad, size_t leftPad, size_t rightPad)
+{
+   size_t nColsA = A.GetNcols();
+   size_t nColsB = B.GetNcols();
+
+   for (size_t i = 0; i < A.GetNrows(); i++) {
+      for (size_t j = 0; j < A.GetNcols(); j++) {
+         if(i<topPad || (i>B.GetNrows() && i<bottomPad) || j<leftPad || (j>B.GetNcols() && j<rightPad)){
+            A(i, j) = 0;
+         }
+         else{
+            A(i, j) = B(i-leftPad, j-topPad);
+         }
+      }
+   }
+}
+
 //____________________________________________________________________________
 template <typename AFloat>
 void TCpu<AFloat>::Reshape(TCpuMatrix<AFloat> &A, const TCpuMatrix<AFloat> &B)

--- a/tmva/tmva/src/DNN/Architectures/Cpu/Propagation.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/Propagation.cxx
@@ -581,7 +581,7 @@ void TCpu<AFloat>::MaxPoolLayerBackward(std::vector<TCpuMatrix<AFloat>> &activat
 
 //______________________________________________________________________________
 template <typename AFloat>
-void TReference<AFloat>::ZeroPad2DForward(TCpuMatrix<AFloat> &A, const TCpuMatrix<AFloat> &B, 
+void TCpu<AFloat>::ZeroPad2DForward(TCpuMatrix<AFloat> &A, const TCpuMatrix<AFloat> &B, 
                                          size_t topPad, size_t bottomPad, size_t leftPad,
                                          size_t rightPad, size_t outputHeight, size_t outputWidth)
 {
@@ -606,7 +606,7 @@ void TReference<AFloat>::ZeroPad2DForward(TCpuMatrix<AFloat> &A, const TCpuMatri
 
 //______________________________________________________________________________
 template <typename AFloat>
-void TReference<AFloat>::ZeroPad2DBackward(std::vector<TCpuMatrix<AFloat>> &activationGradientsBackward,
+void TCpu<AFloat>::ZeroPad2DBackward(std::vector<TCpuMatrix<AFloat>> &activationGradientsBackward,
                                           const std::vector<TCpuMatrix<AFloat>> &activationGradients,
                                           size_t topPad, size_t bottomPad, size_t leftPad,
                                           size_t rightPad, size_t outputHeight, size_t outputWidth,   
@@ -621,7 +621,7 @@ void TReference<AFloat>::ZeroPad2DBackward(std::vector<TCpuMatrix<AFloat>> &acti
          // initialize to zeros
          for (size_t t = 0; t < (size_t)activationGradientsBackward[i].GetNcols(); t++) {
             size_t idx = outputWidth * topPad + (t/inputWidth) * outputWidth + t%inputWidth + leftPad;
-            activationGradientsBackward[i][j][t] = activationGradients[i][j][idx];
+            activationGradientsBackward[i](j, t) = activationGradients[i](j, idx);
          }
 
       }

--- a/tmva/tmva/src/DNN/Architectures/Reference/Propagation.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Reference/Propagation.cxx
@@ -427,14 +427,20 @@ void TReference<AReal>::ZeroPad2DForward(TMatrixT<AReal> &A, const TMatrixT<ARea
 template <typename AReal>
 void TReference<AReal>::ZeroPad2DBackward(std::vector<TMatrixT<AReal>> &activationGradientsBackward,
                                           const std::vector<TMatrixT<AReal>> &activationGradients,
+                                          size_t topPad, size_t bottomPad, size_t leftPad,
+                                          size_t rightPad, size_t outputHeight, size_t outputWidth,   
                                           size_t batchSize, size_t depth)
 {
+   size_t inputHeight = outputHeight - topPad - bottomPad;
+   size_t inputWidth  = outputWidth - leftPad - rightPad; 
+
    for (size_t i = 0; i < batchSize; i++) {
       for (size_t j = 0; j < depth; j++) {
 
          // initialize to zeros
          for (size_t t = 0; t < (size_t)activationGradientsBackward[i].GetNcols(); t++) {
-            activationGradientsBackward[i][j][t] = activationGradients[i][j][t];
+            size_t idx = outputWidth * topPad + (t/inputWidth) * outputWidth + t%inputWidth + leftPad;
+            activationGradientsBackward[i][j][t] = activationGradients[i][j][idx];
          }
 
       }

--- a/tmva/tmva/src/DNN/Architectures/Reference/Propagation.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Reference/Propagation.cxx
@@ -400,6 +400,49 @@ void TReference<AReal>::MaxPoolLayerBackward(std::vector<TMatrixT<AReal>> &activ
 
 //______________________________________________________________________________
 template <typename AReal>
+void TReference<AReal>::ZeroPad2DForward(TMatrixT<AReal> &A, const TMatrixT<AReal> &B, 
+                                         size_t topPad, size_t bottomPad, size_t leftPad,
+                                         size_t rightPad, size_t outputHeight, size_t outputWidth)
+{
+   auto nColsA = A.GetNcols();
+   auto nColsB = B.GetNcols();   
+
+   for (Int_t i = 0; i < A.GetNrows(); i++) {
+      Int_t original_idx = 0;
+      for (Int_t j = 0; j < A.GetNcols(); j++) {
+         Int_t row = j / outputHeight;
+         Int_t col = j - (row*outputWidth);
+         if(row<topPad || (row>(outputHeight-topPad-bottomPad) && row<bottomPad) || col<leftPad || (col>(outputWidth-leftPad-rightPad) && col<rightPad)){
+            A(i, j) = 0;
+         }
+         else{
+            A(i, j) = B(i, original_idx);
+            original_idx += 1;
+         }
+      }
+   }
+}
+
+//______________________________________________________________________________
+template <typename AReal>
+void TReference<AReal>::ZeroPad2DBackward(std::vector<TMatrixT<AReal>> &activationGradientsBackward,
+                                          const std::vector<TMatrixT<AReal>> &activationGradients,
+                                          size_t batchSize, size_t depth)
+{
+   for (size_t i = 0; i < batchSize; i++) {
+      for (size_t j = 0; j < depth; j++) {
+
+         // initialize to zeros
+         for (size_t t = 0; t < (size_t)activationGradientsBackward[i].GetNcols(); t++) {
+            activationGradientsBackward[i][j][t] = activationGradients[i][j][t];
+         }
+
+      }
+   }
+}
+
+//______________________________________________________________________________
+template <typename AReal>
 void TReference<AReal>::Reshape(TMatrixT<AReal> &A, const TMatrixT<AReal> &B)
 {
    auto nColsA = A.GetNcols();

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -496,8 +496,8 @@ void MethodDL::CreateDeepNet(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
       } else if (strLayerType == "LSTM") {
          Log() << kFATAL << "LSTM Layer is not yet fully implemented" << Endl;
          //ParseLstmLayer(deepNet, nets, layerString->GetString(), subDelimiter);
-      } else if (strLayerType == "PADDING") {
-         ParsePaddingLayer(deepNet, nets, layerString->GetString(), subDelimiter);
+      } else if (strLayerType == "PADDING2D") {
+         ParsePaddingLayer2D(deepNet, nets, layerString->GetString(), subDelimiter);
       }
    }
 }
@@ -883,7 +883,7 @@ void MethodDL::ParseLstmLayer(DNN::TDeepNet<Architecture_t, Layer_t> & /*deepNet
 ////////////////////////////////////////////////////////////////////////////////
 /// Pases the layer string and creates the appropriate padding layer
 template <typename Architecture_t, typename Layer_t>
-void MethodDL::ParsePaddingLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
+void MethodDL::ParsePaddingLayer2D(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
                                  std::vector<DNN::TDeepNet<Architecture_t, Layer_t>> & /*nets*/, TString layerString,
                                  TString delim)
 {
@@ -891,6 +891,8 @@ void MethodDL::ParsePaddingLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet
    int bottomPad = 0;
    int leftPad = 0;
    int rightPad = 0;
+
+   //layout expected: topPad|bottomPad|leftPad|rightPad
 
    // Split layer details
    TObjArray *subStrings = layerString.Tokenize(delim);
@@ -926,10 +928,10 @@ void MethodDL::ParsePaddingLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet
    }
 
    // Add the padding layer
-   deepNet.AddPaddingLayer(topPad, bottomPad, leftPad, rightPad);
+   deepNet.AddPaddingLayer2D(topPad, bottomPad, leftPad, rightPad);
 
    // Add the same layer to fNet
-   if (fBuildNet) fNet->AddPaddingLayer(topPad, bottomPad, leftPad, rightPad);
+   if (fBuildNet) fNet->AddPaddingLayer2D(topPad, bottomPad, leftPad, rightPad);
    
 }
 
@@ -1693,7 +1695,7 @@ void MethodDL::ReadWeightsFromXML(void * rootXML)
          fNet->AddBasicRNNLayer(stateSize, inputSize, timeSteps, rememberState);
          
       }
-      else if (layerName == "PaddingLayer") {
+      else if (layerName == "PaddingLayer2D") {
 
          // read reshape layer info
          size_t leftPad, rightPad, topPad, bottomPad = 0; 
@@ -1702,7 +1704,7 @@ void MethodDL::ReadWeightsFromXML(void * rootXML)
          gTools().ReadAttr(layerXML, "TopPad", topPad);
          gTools().ReadAttr(layerXML, "BottomPad", bottomPad);
 
-         fNet->AddPaddingLayer(topPad, bottomPad, leftPad, rightPad);
+         fNet->AddPaddingLayer2D(topPad, bottomPad, leftPad, rightPad);
 
       }      
 

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -496,6 +496,8 @@ void MethodDL::CreateDeepNet(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
       } else if (strLayerType == "LSTM") {
          Log() << kFATAL << "LSTM Layer is not yet fully implemented" << Endl;
          //ParseLstmLayer(deepNet, nets, layerString->GetString(), subDelimiter);
+      } else if (strLayerType == "PADDING") {
+         ParseRnnLayer(deepNet, nets, layerString->GetString(), subDelimiter);
       }
    }
 }
@@ -876,6 +878,59 @@ void MethodDL::ParseLstmLayer(DNN::TDeepNet<Architecture_t, Layer_t> & /*deepNet
       }
       ++idxToken;
    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Pases the layer string and creates the appropriate padding layer
+template <typename Architecture_t, typename Layer_t>
+void MethodDL::ParsePaddingLayer(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
+                                 std::vector<DNN::TDeepNet<Architecture_t, Layer_t>> & /*nets*/, TString layerString,
+                                 TString delim)
+{
+   int topPad = 0;
+   int bottomPad = 0;
+   int leftPad = 0;
+   int rightPad = 0;
+
+   // Split layer details
+   TObjArray *subStrings = layerString.Tokenize(delim);
+   TIter nextToken(subStrings);
+   TObjString *token = (TObjString *)nextToken();
+   int idxToken = 0;
+
+   for (; token != nullptr; token = (TObjString *)nextToken()) {
+
+      switch (idxToken) {
+      case 1: // top padding
+      {
+         TString strTopPad(token->GetString());
+         topPad = strTopPad.Atoi();
+      } break;
+      case 2: // bottom padding
+      {
+         TString strBottomPad(token->GetString());
+         bottomPad = strBottomPad.Atoi();
+      } break;
+      case 3: // left padding
+      {
+         TString strLeftPad(token->GetString());
+         leftPad = strLeftPad.Atoi();
+      } break;
+      case 4: // right padding
+      {
+         TString strRightPad(token->GetString());
+         rightPad = strRightPad.Atoi();
+      } break;
+      }
+      ++idxToken;
+   }
+
+   // Add the padding layer
+   deepNet.AddPaddingLayer(topPad, bottomPad, leftPad, rightPad);
+
+   // Add the same layer to fNet
+   if (fBuildNet) fNet->AddPaddingLayer(topPad, bottomPad, leftPad, rightPad);
+   
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -497,7 +497,7 @@ void MethodDL::CreateDeepNet(DNN::TDeepNet<Architecture_t, Layer_t> &deepNet,
          Log() << kFATAL << "LSTM Layer is not yet fully implemented" << Endl;
          //ParseLstmLayer(deepNet, nets, layerString->GetString(), subDelimiter);
       } else if (strLayerType == "PADDING") {
-         ParseRnnLayer(deepNet, nets, layerString->GetString(), subDelimiter);
+         ParsePaddingLayer(deepNet, nets, layerString->GetString(), subDelimiter);
       }
    }
 }

--- a/tmva/tmva/src/MethodDL.cxx
+++ b/tmva/tmva/src/MethodDL.cxx
@@ -1693,6 +1693,18 @@ void MethodDL::ReadWeightsFromXML(void * rootXML)
          fNet->AddBasicRNNLayer(stateSize, inputSize, timeSteps, rememberState);
          
       }
+      else if (layerName == "PaddingLayer") {
+
+         // read reshape layer info
+         size_t leftPad, rightPad, topPad, bottomPad = 0; 
+         gTools().ReadAttr(layerXML, "LeftPad", leftPad);
+         gTools().ReadAttr(layerXML, "RightPad", rightPad);
+         gTools().ReadAttr(layerXML, "TopPad", topPad);
+         gTools().ReadAttr(layerXML, "BottomPad", bottomPad);
+
+         fNet->AddPaddingLayer(topPad, bottomPad, leftPad, rightPad);
+
+      }      
 
 
       // read eventually weights and biases

--- a/tmva/tmva/test/DNN/CNN/TestMethodDL.cxx
+++ b/tmva/tmva/test/DNN/CNN/TestMethodDL.cxx
@@ -33,7 +33,7 @@ int main()
 
    TString archCPU = "CPU";
 
-   testMethodDL_DNN(archCPU);
+   //testMethodDL_DNN(archCPU);
    testMethodDL_CNN(archCPU);
 
 }

--- a/tmva/tmva/test/DNN/CNN/TestMethodDL.h
+++ b/tmva/tmva/test/DNN/CNN/TestMethodDL.h
@@ -101,7 +101,7 @@ void testMethodDL_CNN(TString architectureStr)
    TString batchLayoutString("BatchLayout=256|1|64");
 
    // General layout.
-   TString layoutString("Layout=CONV|6|3|3|1|1|0|0|TANH,MAXPOOL|2|2|2|2,RESHAPE|FLAT,DENSE|10|TANH,"
+   TString layoutString("Layout=CONV|6|3|3|1|1|0|0|TANH,PADDING|0|0|0|0,MAXPOOL|2|2|2|2,RESHAPE|FLAT,DENSE|10|TANH,"
                         "DENSE|2|LINEAR");
 
    // Training strategies.

--- a/tmva/tmva/test/DNN/CNN/TestMethodDL.h
+++ b/tmva/tmva/test/DNN/CNN/TestMethodDL.h
@@ -101,7 +101,7 @@ void testMethodDL_CNN(TString architectureStr)
    TString batchLayoutString("BatchLayout=256|1|64");
 
    // General layout.
-   TString layoutString("Layout=CONV|6|3|3|1|1|0|0|TANH,PADDING|0|0|0|0,MAXPOOL|2|2|2|2,RESHAPE|FLAT,DENSE|10|TANH,"
+   TString layoutString("Layout=CONV|6|3|3|1|1|0|0|TANH,PADDING2D|0|0|0|0,MAXPOOL|2|2|2|2,RESHAPE|FLAT,DENSE|10|TANH,"
                         "DENSE|2|LINEAR");
 
    // Training strategies.


### PR DESCRIPTION
This layer introduces arbitrary padding as a separate layer instead of having it in convolution. The idea is to allow only fixed padding types for convolution layer such as `VALID`, `SAME`, `FULL` etc. Since arbitrary padding is still required in some architectures, it's been created as a separate layer. The layer takes 4 arguments:
- Left Pad
- Right Pad
- Top Pad
- Bottom Pad

The expected format for the string is this: `PADDING2D|topPad|bottomPad|leftPad|rightPad`

This contains the naive implementation of padding. ~~More efficient approaches such as pre-allocation, a single data structure for propagations are yet to be discussed.~~



TO-DO

- ~~Tests for padding~~